### PR TITLE
Wrap tables with ids

### DIFF
--- a/_data/libdocFunctions.js
+++ b/_data/libdocFunctions.js
@@ -110,7 +110,7 @@ export default {
             }
         },
         cleanup: async function(content) {
-            content = content.replaceAll(`<table>`, `<div class="o-auto w-100 table-wrapper"><table>`);
+            content = content.replaceAll(`<table`, `<div class="o-auto w-100 table-wrapper"><table`);
             content = content.replaceAll(`</table>`, `</table></div>`);
             content = content.replaceAll(`<p><div`, `<div`);
             content = content.replaceAll(`</div></p>`, `</div>`);


### PR DESCRIPTION
Instead of just wrapping `<table>`, recognize `<table` as pattern. This allows users to create content with specific tables ready for jQuery DataTables.