### PR TITLE
Add navigationMaxDepth filter

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -29,6 +29,7 @@ export default function(eleventyConfig) {
     eleventyConfig.addAsyncFilter("toc", libdocFunctions.filters.toc);
     eleventyConfig.addAsyncFilter("sanitizeJSON", libdocFunctions.filters.sanitizeJson);
     eleventyConfig.addAsyncFilter("gitLastModifiedDate", libdocFunctions.filters.gitLastModifiedDate);
+    eleventyConfig.addAsyncFilter("navigationMaxDepth", libdocFunctions.filters.navigationMaxDepth);
     // END FILTERS
 
     // START COLLECTIONS

--- a/_data/libdocFunctions.js
+++ b/_data/libdocFunctions.js
@@ -180,6 +180,18 @@ export default {
             if (fileHistory == "") { return false }
 
             return fileHistory.split(/\r?\n/)[0];
+        },
+        navigationMaxDepth: async function(entries, maxDepth, currentDepth = 0) {
+            function recurse(entries, maxDepth, currentDepth) {
+                if (currentDepth >= maxDepth) return [];
+                return entries.map(entry => ({
+                    ...entry,
+                    children: entry.children
+                        ? recurse(entry.children, maxDepth, currentDepth + 1)
+                        : []
+                }));
+            }
+            return recurse(entries, maxDepth, currentDepth);
         }
     },
     collections: {

--- a/_includes/libdoc_before_html.liquid
+++ b/_includes/libdoc_before_html.liquid
@@ -84,7 +84,7 @@
 {%- endif -%}
 
 {%- comment -%} Eleventy Navigation {%- endcomment -%}
-{%- assign eleventyNavigationMenu = collections.all | eleventyNavigation | eleventyNavigationToHtml: libdocSystem.navigationOptions -%}
+{%- assign eleventyNavigationMenu = collections.all | eleventyNavigation | navigationMaxDepth: 3 | eleventyNavigationToHtml: libdocSystem.navigationOptions -%}
 {%- assign currentPageHrefAttribute = '<a href="' | append: page.url | append: '"' -%}
 {%- capture currentPageReplacementAttribute -%}{{ currentPageHrefAttribute }} aria-current="page"{%- endcapture -%}
 {%- assign eleventyNavigationMenu = eleventyNavigationMenu | replace: currentPageHrefAttribute, currentPageReplacementAttribute -%}


### PR DESCRIPTION
This filter prevents the navigation sidebar to grow infitely, even if the hierarchy is very deep. It is currently fixed with three levels, but this can be moved to the settings.json later.